### PR TITLE
Revert "[Enfold] Update xlm config file"

### DIFF
--- a/enfold/wpml-config.xml
+++ b/enfold/wpml-config.xml
@@ -7,9 +7,9 @@
         <taxonomy translate="1">portfolio_entries</taxonomy>
     </taxonomies>
     <custom-fields>
-        <custom-field action="copy-once">_aviaLayoutBuilder_active</custom-field>
-        <custom-field action="copy-once">_avia_builder_shortcode_tree</custom-field>
-        <custom-field action="copy-once">_aviaLayoutBuilderCleanData</custom-field>
+        <custom-field action="copy">_aviaLayoutBuilder_active</custom-field>
+        <custom-field action="copy">_avia_builder_shortcode_tree</custom-field>
+        <custom-field action="ignore">_aviaLayoutBuilderCleanData</custom-field>
     </custom-fields>
     <language-switcher-settings>
         <key name="icl_lang_sel_config">


### PR DESCRIPTION
@InoPlugs
we're setting `_aviaLayoutBuilderCleanData`  to ignore and creating it programmatically.

To achieve what you asking, so you can use the 'Duplicate' option. Or you can use WPML -> Translation Management -> Custom XML Configuration and override our online config file.