### PR TITLE
Add new Avia Layout Builder Element 'Timeline' to WPML config file

### DIFF
--- a/enfold/wpml-config.xml
+++ b/enfold/wpml-config.xml
@@ -73,6 +73,14 @@
             </attributes>
         </shortcode>
         <shortcode>
+            <tag>av_timeline_item</tag>
+            <attributes>
+                <attribute>title</attribute>
+                <attribute type="link" encoding="av_link">link</attribute>
+                <attribute>date</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
             <tag>av_font_icon</tag>
             <attributes>
                 <attribute>caption</attribute>


### PR DESCRIPTION
The upcoming Enfold release will have a new Avia Layout Builder element called 'Timeline'.
This is extending the WPML config file for that element.