### PR TITLE
Update wpml-config.xml for Avada in order to handle encoded content for the fusion_code tag

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -177,7 +177,7 @@
             <tag>fusion_li_item</tag>
         </shortcode>
         <shortcode>
-            <tag>fusion_code</tag>
+            <tag encoding="base64" encoding-condition="option:avada_disable_encoding=1">fusion_code</tag>
         </shortcode>
         <shortcode>
             <tag>fusion_builder_row</tag>


### PR DESCRIPTION
Tested this also with current master and it doesn't break anything, meaning it's backwards compatible.
The rest of this fix will be included in WPML 4.0

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-5227