### PR TITLE
Added The7 WPBakery Page Builder

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -9,6 +9,7 @@
 		<item id="js_composer" override_local="true">WPBakery Visual Composer</item>
 		<item id="js_composer" override_local="true">WPBakery Page Builder</item>
 		<item id="js_composer" override_local="true">Uncode Page Builder (Visual Composer)</item>
+		<item id="js_composer" override_local="true">The7 WPBakery Page Builder</item>
 		<item id="mailchimp-for-wp" override_local="true">MailChimp for WordPress</item>
 		<item id="members">Members</item>
 		<item id="multibanco-ifthenpay-gateway-for-woocommerce">Multibanco (IfthenPay gateway) for WooCommerce</item>


### PR DESCRIPTION
Dream Theme forked plugin The7 WPBakery Page Builder should use same config as WPBPB. Config for custom cells can be found in theme's config file.