### PR TITLE
Adding link_option_url to text and blurb modules

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -84,6 +84,7 @@
                 <attribute>alt</attribute>
                 <attribute type="media-url">background_image</attribute>
 				<attribute type="link">link_option_url</attribute>
+				<attribute type="link">url</attribute>
             </attributes>
         </shortcode>
         <shortcode>

--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -74,6 +74,7 @@
             <tag>et_pb_text</tag>
             <attributes>
                 <attribute type="media-url">background_image</attribute>
+				<attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>
@@ -82,6 +83,7 @@
                 <attribute>title</attribute>
                 <attribute>alt</attribute>
                 <attribute type="media-url">background_image</attribute>
+				<attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
This should fix https://github.com/OnTheGoSystems/wpml-config/pull/61 and a request from a client regarding the blurb module.