### PR TITLE
Merge the 2 xpaths of the list block

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -89,8 +89,7 @@
             <xpath>//figure/img/@alt</xpath>
         </gutenberg-block>
         <gutenberg-block type="core/list" translate="1">
-            <xpath>//ul/li</xpath>
-            <xpath>//ol/li</xpath>
+            <xpath>//ul/li|//ol/li</xpath>
         </gutenberg-block>
         <gutenberg-block type="core/quote" translate="1">
             <xpath>//blockquote/p</xpath>


### PR DESCRIPTION
This is required for nested lists in order to have the strings in the
correct order when we have a mix of nested lists.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6613