### PR TITLE
Setting Elementor custom fields to ignore

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -4,6 +4,8 @@
         <custom-field action="copy">_elementor_edit_mode</custom-field>
         <custom-field action="copy">_elementor_template_type</custom-field>
         <custom-field action="copy">_elementor_version</custom-field>
+        <custom-field action="ignore">_elementor_data</custom-field>
+        <custom-field action="ignore">_elementor_css</custom-field>
     </custom-fields>
     <custom-types>
         <custom-type translate="1" display-as-translated="1">elementor_library</custom-type>


### PR DESCRIPTION
_elementor_css and _elementor_data have to be set to 'ignore' to avoid clients altering them.