### PR TITLE
Preselect filterbar titles by default.

### DIFF
--- a/the-events-calendar/wpml-config.xml
+++ b/the-events-calendar/wpml-config.xml
@@ -60,5 +60,10 @@
       <key name="dateTimeSeparator"/>
       <key name="timeRangeSeparator"/>
     </key>
+    <key name="tribe_events_filters_current_active_filters">
+      <key name="*">
+        <key name="title" />
+      </key>
+    </key>
   </admin-texts>
 </wpml-config>


### PR DESCRIPTION
This will allow us to simplify the workflow and the documentation:
https://support.theeventscalendar.com/757419-Setting-up-Filter-Bar-with-WPML