### PR TITLE
Change to et_pb_code shortcode

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -177,8 +177,6 @@
                 <attribute>button_text</attribute>
                 <attribute type="link">button_url</attribute>
                 <attribute type="media-url">background_image</attribute>
-                <attributetype="link">link_option_url</attribute>
-                <attribute>admin_label</attribute>
             </attributes>
         </shortcode>
         <shortcode>
@@ -188,6 +186,7 @@
                 <attribute>background_video_mp4</attribute>
                 <attribute>background_video_webm</attribute>
                 <attribute type="link">link_option_url</attribute>
+                <attribute>admin_label</attribute>
             </attributes>
         </shortcode>
         <shortcode>

--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -177,6 +177,17 @@
                 <attribute>button_text</attribute>
                 <attribute type="link">button_url</attribute>
                 <attribute type="media-url">background_image</attribute>
+                <attributetype="link">link_option_url</attribute>
+                <attribute>admin_label</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>et_pb_code</tag>
+            <attributes>
+                <attribute>background_image</attribute>
+                <attribute>background_video_mp4</attribute>
+                <attribute>background_video_webm</attribute>
+                <attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>

--- a/divi-builder/wpml-config.xml
+++ b/divi-builder/wpml-config.xml
@@ -180,6 +180,15 @@
             </attributes>
         </shortcode>
         <shortcode>
+            <tag>et_pb_code</tag>
+            <attributes>
+                <attribute>background_image</attribute>
+                <attribute>background_video_mp4</attribute>
+                <attribute>background_video_webm</attribute>
+                <attribute type="link">link_option_url</attribute>
+            </attributes>
+        </shortcode>        
+        <shortcode>
             <tag>et_pb_countdown_timer</tag>
             <attributes>
                 <attribute>title</attribute>

--- a/divi-builder/wpml-config.xml
+++ b/divi-builder/wpml-config.xml
@@ -186,8 +186,9 @@
                 <attribute>background_video_mp4</attribute>
                 <attribute>background_video_webm</attribute>
                 <attribute type="link">link_option_url</attribute>
+                <attribute>admin_label</attribute>
             </attributes>
-        </shortcode>        
+        </shortcode>
         <shortcode>
             <tag>et_pb_countdown_timer</tag>
             <attributes>


### PR DESCRIPTION
Adding attributes for the et_pb_code shortcode in the /wpml-config/Divi/ and /wpml-config/divi-builder/ folders. Coming from this support ticket.
https://wpml.org/forums/topic/split-adding-a-new-divi-module-to-an-already-existing-page-becomes-a-mess-in-the-translation-editor/page/2/