### PR TITLE
Copy post meta to flag the PB editor in Beaver Builder, Cornerstone & Elementor

### DIFF
--- a/beaver-builder/wpml-config.xml
+++ b/beaver-builder/wpml-config.xml
@@ -1,0 +1,5 @@
+<wpml-config>
+	<custom-fields>
+		<custom-field action="copy">_fl_builder_enabled</custom-field>
+	</custom-fields>
+</wpml-config>

--- a/config-index.xml
+++ b/config-index.xml
@@ -2,6 +2,8 @@
 	<plugins>
 		<item id="10bit-woocommerce-gateway-yaadpay" override_local="true">10bit WooCommerce Gateway Yaadpay</item>
 		<item id="book-now">Book Now</item>
+		<item id="beaver-builder" override_local="true">Beaver Builder Plugin (Lite Version)</item>
+		<item id="beaver-builder" override_local="true">Beaver Builder Plugin (Pro Version)</item>
 		<item id="cornerstone" override_local="true">Cornerstone</item>
 		<item id="custom-post-type-ui" override_local="true">Custom Post Type UI</item>
 		<item id="divi-builder" override_local="true">Divi Builder</item>

--- a/cornerstone/wpml-config.xml
+++ b/cornerstone/wpml-config.xml
@@ -23,6 +23,7 @@
         <custom-field action="copy">_x_portfolio_project_link</custom-field>
         <custom-field action="copy">_x_portfolio_embed</custom-field>
         <custom-field action="copy">_cornerstone_data</custom-field>
+        <custom-field action="copy">_cornerstone_override</custom-field>
     </custom-fields>
     <admin-texts>
         <key name="x_integrity_blog_title"/>

--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -6,6 +6,7 @@
         <custom-field action="copy">_elementor_version</custom-field>
         <custom-field action="copy-once">_elementor_data</custom-field>
         <custom-field action="ignore">_elementor_css</custom-field>
+        <custom-field action="copy">_elementor_edit_mode</custom-field>
     </custom-fields>
     <custom-types>
         <custom-type translate="1" display-as-translated="1">elementor_library</custom-type>


### PR DESCRIPTION
This is required because if the PB editor is disabled, we won't run all
the logic when the translation job is saved (and so the post meta wouldn't be
copied).

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6929