### PR TITLE
Bold Page Builder config

### DIFF
--- a/bold-page-builder/wpml-config.xml
+++ b/bold-page-builder/wpml-config.xml
@@ -1,3 +1,51 @@
 <wpml-config>
-    <shortcode-list>bt_bb_headline,bt_bb_service</shortcode-list>
+    <shortcode-list>bt_accordion_items,bt_header,bt_button,bt_image,bt_service</shortcode-list>
+    
+     <shortcodes>
+        
+        <shortcode>
+            <tag>bt_accordion_items</tag>
+            <attributes>
+                <attribute>headline</attribute>
+                <attribute>headline</attribute>
+            </attributes>
+        </shortcode>
+    
+        <shortcode>
+            <tag>bt_header</tag>
+            <attributes>
+                <attribute>superheadline</attribute>
+                <attribute>headline</attribute>
+                <attribute>subheadline</attribute>
+            </attributes>
+        </shortcode>
+        
+        <shortcode>
+            <tag>bt_button</tag>
+            <attributes>
+                <attribute>text</attribute>
+                <attribute type="url">url</attribute>
+            </attributes>
+        </shortcode>
+        
+         <shortcode>
+            <tag>bt_image</tag>
+            <attributes>
+                <attribute type="media-ids">image</attribute>
+                <attribute>caption_text</attribute>
+                <attribute>caption_title</attribute>
+                <attribute type="link">url</attribute>
+            </attributes>
+        </shortcode>
+        
+        <shortcode>
+            <tag>bt_service</tag>
+            <attributes>
+                <attribute>headline</attribute>
+                <attribute>text</attribute>
+                <attribute>caption_title</attribute>
+                <attribute type="link">url</attribute>
+            </attributes>
+        </shortcode>
+    </shortcodes>
 </wpml-config>


### PR DESCRIPTION
Added basic short codes for the [Bold Page Builder](https://wordpress.org/plugins/bold-page-builder/). Only the most important elements (for me) are supported at the moment.