### PR TITLE
Add support for image block's title/alt when there's a link on the image

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -81,8 +81,8 @@
         </gutenberg-block>
         <gutenberg-block type="core/image" translate="1">
             <xpath>//figure/figcaption</xpath>
-            <xpath>//figure/img/@alt</xpath>
-            <xpath>//figure/img/@title</xpath>
+            <xpath>//figure//img/@alt</xpath>
+            <xpath>//figure//img/@title</xpath>
             <xpath type='link'>//figure/a/@href</xpath>
         </gutenberg-block>
         <gutenberg-block type="core/gallery" translate="1">


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7294