### PR TITLE
Update config for Custom Post Type UI

### DIFF
--- a/custom-post-type-ui/wpml-config.xml
+++ b/custom-post-type-ui/wpml-config.xml
@@ -1,9 +1,11 @@
 <wpml-config>
     <admin-texts>
-        <key name="cptui_post_types">
+        <key name="cptui_*">
             <key name="*">
                 <key name="label"/>
                 <key name="singular_label"/>
+                <key name="labels">
+                    <key name="*" /></key>
             </key>
         </key>
     </admin-texts>


### PR DESCRIPTION
Made the option `cptui_taxonomies` translatable in the same way as `cptui_post_type` + Added the ability to translate the other labels of these custom types.

https://onthegosystems.myjetbrains.com/youtrack/issue/comp-3502