### PR TITLE
Make Beaver Builder's taxonomy `fl-builder-template-type` not translatable

### DIFF
--- a/beaver-builder/wpml-config.xml
+++ b/beaver-builder/wpml-config.xml
@@ -1,4 +1,7 @@
 <wpml-config>
+	<taxonomies>
+		<taxonomy translate="0">fl-builder-template-type</taxonomy>
+	</taxonomies>
 	<custom-fields>
 		<custom-field action="copy">_fl_builder_enabled</custom-field>
 	</custom-fields>


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/comp-3458