### PR TITLE
Update config file for Sensei LMS

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -20,7 +20,7 @@
 		<item id="nw-adcart-for-woocommerce" override_local="true">NW ADCart for WooCommerce</item>
 		<item id="paypal-for-woocommerce" override_local="true">PayPal for WooCommerce</item>
 		<item id="product-enquiry-pro-for-woocommerce" override_local="true">Product Enquiry Pro for WooCommerce</item>
-		<item id="sensei" override_local="true">Sensei</item>
+		<item id="sensei">Sensei LMS</item>
 		<item id="subscriptio">Subscriptio</item>
 		<item id="sitepress-multilingual-cms" override_local="true">WPML Multilingual CMS</item>
 		<item id="the-events-calendar" override_local="true">The Events Calendar</item>

--- a/config-index.xml
+++ b/config-index.xml
@@ -20,6 +20,7 @@
 		<item id="nw-adcart-for-woocommerce" override_local="true">NW ADCart for WooCommerce</item>
 		<item id="paypal-for-woocommerce" override_local="true">PayPal for WooCommerce</item>
 		<item id="product-enquiry-pro-for-woocommerce" override_local="true">Product Enquiry Pro for WooCommerce</item>
+		<item id="sensei">Sensei</item>
 		<item id="sensei">Sensei LMS</item>
 		<item id="subscriptio">Subscriptio</item>
 		<item id="sitepress-multilingual-cms" override_local="true">WPML Multilingual CMS</item>

--- a/sensei/wpml-config.xml
+++ b/sensei/wpml-config.xml
@@ -10,10 +10,9 @@
 	<custom-types>
 		<custom-type translate="1">course</custom-type>
 		<custom-type translate="1">lesson</custom-type>
-		<custom-type translate="0">multiple_question</custom-type>
+		<custom-type translate="1">multiple_question</custom-type>
 		<custom-type translate="1">question</custom-type>
-		<custom-type translate="0">quiz</custom-type>
-		<custom-type translate="0">sensei_message</custom-type>
+		<custom-type translate="1">quiz</custom-type>
 	</custom-types>
 	<taxonomies>
 		<taxonomy translate="1">course-category</taxonomy>

--- a/sensei/wpml-config.xml
+++ b/sensei/wpml-config.xml
@@ -1,30 +1,30 @@
 <wpml-config>
-    <custom-fields>
-        <custom-field action="copy">_lesson_complexity</custom-field>
-        <custom-field action="copy">_lesson_length</custom-field>
-        <custom-field action="translate">_lesson_prerequisite</custom-field>
-        <custom-field action="translate">_lesson_course</custom-field>
-        <custom-field action="translate">_course_prerequisite</custom-field>
-        <custom-field action="translate">_course_woocommerce_product</custom-field>
-    </custom-fields>
+	<custom-fields>
+		<custom-field action="copy">_lesson_complexity</custom-field>
+		<custom-field action="copy">_lesson_length</custom-field>
+		<custom-field action="translate">_lesson_prerequisite</custom-field>
+		<custom-field action="translate">_lesson_course</custom-field>
+		<custom-field action="translate">_course_prerequisite</custom-field>
+		<custom-field action="translate">_course_woocommerce_product</custom-field>
+	</custom-fields>
 	<custom-types>
 		<custom-type translate="1">course</custom-type>
 		<custom-type translate="1">lesson</custom-type>
-		<custom-type translate="1">quiz</custom-type>
+		<custom-type translate="0">multiple_question</custom-type>
 		<custom-type translate="1">question</custom-type>
-		<custom-type translate="1">multiple_question</custom-type>
-		<custom-type translate="1">sensei_message</custom-type>
+		<custom-type translate="0">quiz</custom-type>
+		<custom-type translate="0">sensei_message</custom-type>
 	</custom-types>
 	<taxonomies>
-		<taxonomy translate="1">lesson-tag</taxonomy>
 		<taxonomy translate="1">course-category</taxonomy>
+		<taxonomy translate="1">lesson-tag</taxonomy>
+		<taxonomy translate="1">module</taxonomy>
+		<taxonomy translate="1">question-category</taxonomy>
 	</taxonomies>
-    <admin-texts>
-        <key name="woothemes-sensei-settings">
-            <key name="course_archive_more_link_text" />
-            <key name="heading" />
-            <key name="email_footer_text" />
-            <key name="email_footer_text_2" />
-        </key>
-    </admin-texts>
+	<admin-texts>
+		<key name="sensei-settings">
+			<key name="course_archive_more_link_text" />
+			<key name="email_footer_text" />
+		</key>
+	</admin-texts>
 </wpml-config>

--- a/sensei/wpml-config.xml
+++ b/sensei/wpml-config.xml
@@ -10,17 +10,22 @@
 	<custom-types>
 		<custom-type translate="1">course</custom-type>
 		<custom-type translate="1">lesson</custom-type>
-		<custom-type translate="1" display-as-translated="1">multiple_question</custom-type>
+		<custom-type translate="1">quiz</custom-type>
 		<custom-type translate="1">question</custom-type>
-		<custom-type translate="1" display-as-translated="1">quiz</custom-type>
+		<custom-type translate="1">multiple_question</custom-type>
+		<custom-type translate="1">sensei_message</custom-type>
 	</custom-types>
 	<taxonomies>
-		<taxonomy translate="1">course-category</taxonomy>
 		<taxonomy translate="1">lesson-tag</taxonomy>
-		<taxonomy translate="1">module</taxonomy>
-		<taxonomy translate="1">question-category</taxonomy>
+		<taxonomy translate="1">course-category</taxonomy>
 	</taxonomies>
 	<admin-texts>
+		<key name="woothemes-sensei-settings">
+			<key name="course_archive_more_link_text" />
+			<key name="heading" />
+			<key name="email_footer_text" />
+			<key name="email_footer_text_2" />
+		</key>
 		<key name="sensei-settings">
 			<key name="course_archive_more_link_text" />
 			<key name="email_footer_text" />

--- a/sensei/wpml-config.xml
+++ b/sensei/wpml-config.xml
@@ -10,9 +10,9 @@
 	<custom-types>
 		<custom-type translate="1">course</custom-type>
 		<custom-type translate="1">lesson</custom-type>
-		<custom-type translate="1">multiple_question</custom-type>
+		<custom-type translate="1" display-as-translated="1">multiple_question</custom-type>
 		<custom-type translate="1">question</custom-type>
-		<custom-type translate="1">quiz</custom-type>
+		<custom-type translate="1" display-as-translated="1">quiz</custom-type>
 	</custom-types>
 	<taxonomies>
 		<taxonomy translate="1">course-category</taxonomy>


### PR DESCRIPTION
This PR updates the config file for Sensei LMS to be the same as https://github.com/Automattic/sensei/pull/3840. In testing, our local version seemed to be overriding the hosted version, but thought it would be safest to make the same updates here.

This PR:
- Enables translating modules, questions and question categories.
- Enables translating user-defined values specified in settings.

It's not clear to me why `quiz`, `multiple_question` and `sensei_message` were previously set to translatable. Messages are sent between teachers and students, so those don't need to be translated, while `quiz` and `multiple_question` aren't directly accessible in WP admin.