### PR TITLE
Add xpath for core/table headers in sitepress-multilingual-cms 

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -122,6 +122,7 @@
 			<xpath>//pre</xpath>
 		</gutenberg-block>
 		<gutenberg-block type="core/table" translate="1">
+			<xpath>//th</xpath>
 			<xpath>//td</xpath>
 			<xpath>//figure/figcaption</xpath>
 		</gutenberg-block>


### PR DESCRIPTION
add //th xpath for core/table so table headers are translatable in the CTE and ATE

Related WPML ticket: https://wpml.org/forums/topic/i-am-not-able-to-find-that-string-for-translation/