### PR TITLE
compsupp-5516 - changes the editor style for _et_pb_old_content

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -26,7 +26,7 @@
         <custom-field action="copy">_et_pb_post_hide_nav</custom-field>
         <custom-field action="copy">_et_pb_show_title</custom-field>
         <custom-field action="copy">_et_pb_use_builder</custom-field>
-        <custom-field action="translate">_et_pb_old_content</custom-field>
+        <custom-field action="translate" style="visual">_et_pb_old_content</custom-field>
         <custom-field action="copy">_et_pb_product_page_layout</custom-field>
         <custom-field action="copy">_et_pb_woo_page_content_status</custom-field>
         <custom-field action="copy">_et_pb_ab_current_shortcode</custom-field>


### PR DESCRIPTION
## Coming from compsupp-5516
The _et_pb_old_content field shows in the translation editor as a line, but it needs to be a text area/wysiwyg.

## What does the fix does?
It adds the style attribute to the field. 