### PR TITLE
[DIVI] Add support for missing responsive image attributes for `et_pb_slide`

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -345,6 +345,8 @@
                 <attribute type="link">button_link</attribute>
                 <attribute type="link">link_option_url</attribute>
                 <attribute type="media-url">image</attribute>
+                <attribute type="media-url">image_tablet</attribute>
+                <attribute type="media-url">image_phone</attribute>
                 <attribute type="media-url">background_image</attribute>
                 <attribute encoding="allow_html_tags">content_tablet</attribute>
                 <attribute encoding="allow_html_tags">content_phone</attribute>


### PR DESCRIPTION
Added attribute definitions for `et_pb_slide`:
- image_tablet
- image_phone