### PR TITLE
The form locale is always set to the User's Profile Language

### DIFF
--- a/contact-form-7-multilingual/wpml-config.xml
+++ b/contact-form-7-multilingual/wpml-config.xml
@@ -8,7 +8,7 @@
         <custom-field action="translate">_mail_2</custom-field>
         <custom-field action="translate">_messages</custom-field>
         <custom-field action="copy">_additional_settings</custom-field>
-        <custom-field action="translate">_locale</custom-field>
+        <custom-field action="copy">_locale</custom-field>
     </custom-fields>
     <custom-fields-texts>
         <key name="_mail">


### PR DESCRIPTION
The form locale is always set to the User's Profile Language rather than the current Admin Language selected by the User.

- Also setting **_locale** custom field to **copy**

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcf7-32

Closes wpmlcf7-32-2