### PR TITLE
Mailchimp - Set Mailchimp setting to copy once.

### DIFF
--- a/mailchimp-for-wp/wpml-config.xml
+++ b/mailchimp-for-wp/wpml-config.xml
@@ -13,6 +13,7 @@
         <custom-field action="translate">text_subscribed</custom-field>
         <custom-field action="translate">text_no_lists_selected</custom-field>
         <custom-field action="translate">text_updated</custom-field>
+        <custom-field action="copy-once">_mc4wp_settings</custom-field>
     </custom-fields>
     <admin-texts>
         <key name="mc4wp_integrations">


### PR DESCRIPTION
Added new custom field `_mc4wp_settings` to copy the setting only once.

https://onthegosystems.myjetbrains.com/youtrack/issue/mcml-8