### PR TITLE
Set fusion_builder_status to copy-once

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -196,7 +196,6 @@
         <custom-field action="copy-once">fusion_builder_status</custom-field>
         <custom-field action="ignore">fusion_demo_import</custom-field>
         <custom-field action="copy-once">_fusion_is_global</custom-field>
-        <custom-field action="ignore">fusion_builder_status</custom-field>
         <custom-field action="copy-once">_fusion_builder_custom_css</custom-field>
         <custom-field action="translate">_fusion</custom-field>
         <custom-field action="copy-once">_menu_item_fusion_megamenu</custom-field>


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-5934

The fusion_builder_status is duplicated with two different settings. Removing the `ignore` one.