### PR TITLE
[Avada] Disable Translate Everything for Avada Forms

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -44,7 +44,7 @@
         <custom-type translate="1">fusion_tb_section</custom-type>
         <custom-type translate="1">fusion_element</custom-type>
         <custom-type translate="0">fusion_icons</custom-type>
-        <custom-type translate="1">fusion_form</custom-type>
+        <custom-type translate="1" automatic="0">fusion_form</custom-type>
     </custom-types>
     <taxonomies>
         <taxonomy translate="1">portfolio_category</taxonomy>


### PR DESCRIPTION
As other "form" CPTs (e.g. CF7), we will disable Translate Everything for Avada Forms as we consider these contents are made of short strings without context for a relevant automatic translation.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmldoc-1560#focus=Comments-102-494584.0-0