### PR TITLE
Update wpml-config.xml

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -53,7 +53,7 @@
         <taxonomy translate="1">portfolio_tags</taxonomy>
         <taxonomy translate="1">themefusion_es_groups</taxonomy>
         <taxonomy translate="1">slide-page</taxonomy>
-        <taxonomy translate="1">fusion_tb_category</taxonomy>
+        <taxonomy translate="0">fusion_tb_category</taxonomy>
         <taxonomy translate="0">element_category</taxonomy>
     </taxonomies>
     <custom-fields>


### PR DESCRIPTION
Seeing PHP notices like this -> https://share.getcloudapp.com/E0uKxpJw when translation is added for layout section. The term is also missing for the translated items.

I believe fusion_tb_category should not be translatable just like element_category