### PR TITLE
WPBakery - Translate the Google Maps widget

### DIFF
--- a/js_composer/wpml-config.xml
+++ b/js_composer/wpml-config.xml
@@ -162,6 +162,7 @@
             <tag>vc_gmaps</tag>
             <attributes>
                 <attribute encoding="allow_html_tags">title</attribute>
+                <attribute encoding="vc_safe">link</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
Allow user to translate iframe in `vc_gmaps` shortcode.
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-9386