### PR TITLE
Add index for the new WCML name "WooCommerce Multilingual & Multicurrency"

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -68,6 +68,7 @@
 		<item id="woocommerce-memberships" override_local="true">WooCommerce Memberships</item>
 		<item id="woocommerce-mix-and-match-products" override_local="true">WooCommerce Mix and Match</item>
 		<item id="woocommerce-multilingual" override_local="true">WooCommerce Multilingual</item>
+		<item id="woocommerce-multilingual" override_local="true">WooCommerce Multilingual & Multicurrency</item>
 		<item id="woocommerce-name-your-price" override_local="true">WooCommerce Name Your Price</item>
 		<item id="woocommerce-paymill-gateway" override_local="true">WooCommerce Paymill Gateway</item>
 		<item id="woocommerce-pdf-invoices-packing-slips" override_local="true">WooCommerce PDF Invoices &amp; Packing Slips</item>


### PR DESCRIPTION
This is just a copy of the original WCML name.

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-3908