### PR TITLE
Removed the encoding from vc_single_image

### DIFF
--- a/js_composer/wpml-config.xml
+++ b/js_composer/wpml-config.xml
@@ -121,7 +121,7 @@
             <attributes>
                 <attribute encoding="allow_html_tags">title</attribute>
                 <attribute type="media-ids">image</attribute>
-                <attribute encoding="vc_link" type="link">link</attribute>
+                <attribute>link</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
It seems that the encoding on link (vc_single_image) was causing some issues. See:
- https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-6148
- https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-6209