### PR TITLE
Add Support for Archive Product Nothing Found Message

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -318,5 +318,11 @@
                 <field type="Shipping details text">shipping_details_text</field>
             </fields>
         </widget>
+        <widget name="wc-archive-products">
+            <fields>
+                <field type="Archive Product: Nothing Found Message" editor_type="LINE">nothing_found_message</field>
+               
+            </fields>
+        </widget>
     </elementor-widgets>
 </wpml-config>

--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -321,7 +321,6 @@
         <widget name="wc-archive-products">
             <fields>
                 <field type="Archive Product: Nothing Found Message" editor_type="LINE">nothing_found_message</field>
-               
             </fields>
         </widget>
     </elementor-widgets>


### PR DESCRIPTION
- The Elementor Pro widget Archive product has an advanced section where nothing found message can be defined. 
- Reported on chat.