### PR TITLE
WPBakery Page Builder - Set post custom CSS to copy

### DIFF
--- a/js_composer/wpml-config.xml
+++ b/js_composer/wpml-config.xml
@@ -7,6 +7,7 @@
     <custom-fields>
         <custom-field action="ignore">_vc_post_settings</custom-field>
         <custom-field action="copy">_wpb_shortcodes_custom_css</custom-field>
+        <custom-field action="copy">_wpb_post_custom_css</custom-field>
     </custom-fields>
     <shortcodes>
         <shortcode>


### PR DESCRIPTION
WPBakery Page Builder has post specific custom CSS option, which is not copied or translated on post translation.
The value is stored in post meta with key `_wpb_post_custom_css`.

Ref:- https://wpml.org/forums/topic/the-background-color-at-the-top-of-the-main-page-is-not-visible/