### PR TITLE
[wpmlpb-245] Support `fusion_post_cards` translation

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -454,6 +454,12 @@
             </attributes>
         </shortcode>
         <shortcode>
+            <tag>fusion_post_cards</tag>
+            <attributes>
+                <attribute type="post-ids">post_card</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
             <tag>fusion_pricing_table</tag>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
With that change, the `fustion_post_cards` in the translated language will show in the translated post.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-245/