### PR TITLE
Adding link_option_url attr to "team member"(DIVI)

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -319,6 +319,7 @@
                 <attribute>position</attribute>
                 <attribute type="media-url">image_url</attribute>
                 <attribute type="media-url">background_image</attribute>
+                <attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>

--- a/divi-builder/wpml-config.xml
+++ b/divi-builder/wpml-config.xml
@@ -313,6 +313,7 @@
                 <attribute>position</attribute>
                 <attribute type="media-url">image_url</attribute>
                 <attribute type="media-url">background_image</attribute>
+                <attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>

--- a/extra/wpml-config.xml
+++ b/extra/wpml-config.xml
@@ -240,6 +240,7 @@
                 <attribute>position</attribute>
                 <attribute type="media-url">image_url</attribute>
                 <attribute type="media-url">background_image</attribute>
+                <attribute type="link">link_option_url</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
We missed the "link" option in the "Team Member" module from Divi (and related Elegant Themes products)