### PR TITLE
Elementor - Fixed issue with Price List widget links.

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -340,8 +340,8 @@
         <widget name="price-list">
             <fields-in-item items_of="price_list">
                 <field type="Pricing list: title">title</field>
-                <field type="Pricing list: description">item_description</field>
-                <field type="Pricing list: link" editor_type="LINK">link>url</field>
+                <field editor_type="AREA" type="Pricing list: description">item_description</field>
+                <field editor_type="LINK" type="Pricing list: link" key_of="link">url</field>
             </fields-in-item>
         </widget>
         <widget name="mega-menu">


### PR DESCRIPTION
`Link>URL` is not working with repeater fields. We need `key_of` to make links translatable. (See wpmlpb-371)
Added `editor_type` attribute to description.
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmltriage-645