### PR TITLE
[wpmldev-2338] Making title and description of navigation-link gutenb…

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -148,6 +148,8 @@
 		<gutenberg-block type="core/navigation-link" translate="1">
 			<key name="label" />
 			<key name="url" />
+			<key name="title" />
+			<key name="description" />
 		</gutenberg-block>
 		<gutenberg-block type="core/navigation-submenu" translate="1">
 			<key name="label" />


### PR DESCRIPTION
Making title and description of navigation-link gutenberg block to be translatable