### PR TITLE
[Kadence blocks Pro] - Add support for PostGrid/Carousel Block

### DIFF
--- a/kadence-blocks/wpml-config.xml
+++ b/kadence-blocks/wpml-config.xml
@@ -70,6 +70,9 @@
 			<key name="content" />
 			<key name="name" />
 			<key name="occupation" />                  
-		</gutenberg-block>  
+		</gutenberg-block>
+		<gutenberg-block type="kadence/postgrid" translate="1">
+			<key name="readMoreText" />
+		</gutenberg-block>		
 	</gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
PostGrid/Carousel Block:
- "Read More" button is not translatable.