### PR TITLE
[wpmlpb-346] Set link type for block attributes in `core/navigation-link` and `core/navigation-submenu`

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -147,13 +147,13 @@
 		</gutenberg-block>
 		<gutenberg-block type="core/navigation-link" translate="1">
 			<key name="label" />
-			<key name="url" />
+			<key name="url" type="link" />
 			<key name="title" />
 			<key name="description" />
 		</gutenberg-block>
 		<gutenberg-block type="core/navigation-submenu" translate="1">
 			<key name="label" />
-			<key name="url" />
+			<key name="url" type="link" />
 		</gutenberg-block>
 		<gutenberg-block type="core/column" translate="0" />
 		<gutenberg-block type="core/columns" translate="0" />


### PR DESCRIPTION
…ink` and `core/navigation-submenu`