### PR TITLE
Divi - Added support for et_pb_slide heading HTML tags

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -357,9 +357,9 @@
         <shortcode>
             <tag>et_pb_slide</tag>
             <attributes>
-                <attribute>heading</attribute>
-                <attribute>heading_tablet</attribute>
-                <attribute>heading_phone</attribute>
+                <attribute encoding="allow_html_tags">heading</attribute>
+                <attribute encoding="allow_html_tags">heading_tablet</attribute>
+                <attribute encoding="allow_html_tags">heading_phone</attribute>
                 <attribute>image_alt</attribute>
                 <attribute>button_text</attribute>
                 <attribute>button_text_tablet</attribute>


### PR DESCRIPTION
- Allowing the heading from the **et_pb_slide** widget to support HTML tags: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7107