### PR TITLE
[acfml-833] Config file for ACF.

### DIFF
--- a/advanced-custom-fields/wpml-config.xml
+++ b/advanced-custom-fields/wpml-config.xml
@@ -1,0 +1,6 @@
+<wpml-config>
+	<custom-types>
+		<custom-type translate="0">acf-post-type</custom-type>
+		<custom-type translate="0">acf-taxonomy</custom-type>
+	</custom-types>
+</wpml-config>

--- a/config-index.xml
+++ b/config-index.xml
@@ -103,6 +103,8 @@
 		<item id="wpml-test-config" override_local="true">WPML Test Config</item>
 		<item id="yoast-seo" override_local="true">Yoast SEO</item>
 		<item id="edd-multilingual" override_local="true">Easy Digital Downloads Multilingual</item>
+		<item id="advanced-custom-fields" override_local="true">Advanced Custom Fields</item>
+		<item id="advanced-custom-fields" override_local="true">Advanced Custom Fields PRO</item>
 	</plugins>
 	<themes>
 		<item id="astra" override_local="true">Astra</item>


### PR DESCRIPTION
- Set the internal post type for CPTs and CTs as not translatable.

https://onthegosystems.myjetbrains.com/youtrack/issue/acfml-833/