### PR TITLE
Divi - Added support for et_pb_cta Hover HTML tags

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -109,8 +109,8 @@
                 <attribute>admin_label</attribute>
                 <attribute>button_text</attribute>
                 <attribute>title_phone</attribute>
-                <attribute>title__hover</attribute>
-                <attribute>content__hover</attribute>
+               <attribute encoding="allow_html_tags">title__hover</attribute>
+                <attribute encoding="allow_html_tags">content__hover</attribute>
                 <attribute>title_tablet</attribute>
                 <attribute>button_text_tablet</attribute>
                 <attribute>button_text_phone</attribute>

--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -109,7 +109,7 @@
                 <attribute>admin_label</attribute>
                 <attribute>button_text</attribute>
                 <attribute>title_phone</attribute>
-               <attribute encoding="allow_html_tags">title__hover</attribute>
+                <attribute encoding="allow_html_tags">title__hover</attribute>
                 <attribute encoding="allow_html_tags">content__hover</attribute>
                 <attribute>title_tablet</attribute>
                 <attribute>button_text_tablet</attribute>


### PR DESCRIPTION
- Allowing the Hover from the et_pb_cta widget to support HTML tags: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7220