### PR TITLE
Enfold - Enabling Media Translation for column background images

### DIFF
--- a/enfold/wpml-config.xml
+++ b/enfold/wpml-config.xml
@@ -70,6 +70,66 @@
     </language-switcher-settings>
     <shortcodes>
         <shortcode>
+            <tag>av_one_half</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_one_full</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_one_third</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_one_fourth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_one_fifth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_two_third</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_three_fourth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_two_fifth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_three_fifth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>av_four_fifth</tag>
+            <attributes>
+                <attribute type="post-ids" sub-type="attachment">attachment</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
             <tag>av_textblock</tag>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
- Allowing that images added as background in columns can be translated with Media Translation
- https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7248