### PR TITLE
Enfold - Fixed links encoding in Fullscreen Slider widget.

### DIFF
--- a/enfold/wpml-config.xml
+++ b/enfold/wpml-config.xml
@@ -388,9 +388,9 @@
             <attributes>
                 <attribute>title</attribute>
                 <attribute>button_label</attribute>
-                <attribute>link1</attribute>
+                <attribute type="link" encoding="av_link">link1</attribute>
                 <attribute>button_label2</attribute>
-                <attribute>link2</attribute>
+                <attribute type="link" encoding="av_link">link2</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
Links in Fullscreen sliders are not translated when using automatic translation. This is because links are missing the encoding attribute in config.

See https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-11594