### PR TITLE
Adding Spectra plugin to config.index.ml file

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -58,7 +58,7 @@
 		<item id="subscriptio">Subscriptio</item>
 		<item id="the-events-calendar" override_local="true">The Events Calendar</item>
 		<item id="ultimate-addons-for-gutenberg" override_local="true">Ultimate Addons for Gutenberg</item>
-		<item id="ultimate-addons-for-gutenberg" override_local="true">Spectra – WordPress Gutenberg Blocks</item>
+		<item id="ultimate-addons-for-gutenberg" override_local="true">Spectra</item>
 		<item id="ultimate-member" override_local="true">Ultimate Member</item>
 		<item id="uncode-js_composer" override_local="true">Uncode Page Builder (Visual Composer)</item>
 		<item id="uncode-js_composer" override_local="true">Uncode WPBakery Page Builder</item>


### PR DESCRIPTION
- Adding Spectra (old Ultimate Addons for Gutenberg) to config.index.ml file
- Modifying the plugin's name
https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7376