### PR TITLE
[Avada] - Added support for translating images in "fusion_imageframe" widget

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -391,7 +391,7 @@
             </attributes>
         </shortcode>
         <shortcode>
-            <tag ignore-content="1">fusion_imageframe</tag>
+            <tag type="media-url">fusion_imageframe</tag>
             <attributes>
                 <attribute label="Image: Alt Text">alt</attribute>
                 <attribute label="Image: Link" type="link">link</attribute>


### PR DESCRIPTION
- Added support for translating images in "fusion_imageframe" widget
- https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7403/Avada-Switched-images-are-not-shown-on-the-translated-page-Fusion-builder