### PR TITLE
wpmlsupp-11848: update Avada config

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -391,7 +391,7 @@
             </attributes>
         </shortcode>
         <shortcode>
-            <tag ignore-content="1">fusion_imageframe</tag>
+            <tag>fusion_imageframe</tag>
             <attributes>
                 <attribute label="Image: Alt Text">alt</attribute>
                 <attribute label="Image: Link" type="link">link</attribute>


### PR DESCRIPTION
In this previous commit (https://github.com/OnTheGoSystems/wpml-config/commit/d53acd46cea52aa9ded6c94a0926c0f5748c7718) we added `<tag ignore-content="1">fusion_imageframe</tag>` to the fusion_imageframe shortcode.

This is causing issues in wpmlsupp-11848 and compsupp-7403

Would it be possible to remove that?