### PR TITLE
[wpmlpb-520] Translate strings in Search widget

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -391,6 +391,13 @@
                 <field type="Lottie: Caption" editor_type="LINE">caption</field>
                 <field type="Lottie: Link" editor_type="LINK">custom_link>url</field>
             </fields>
-        </widget>	    
+        </widget>
+        <widget name="search">
+            <fields>
+                <field>search_input_placeholder_text</field>
+                <field>submit_button_text</field>
+                <field>nothing_found_message_text</field>
+            </fields>
+        </widget>
     </elementor-widgets>
 </wpml-config>


### PR DESCRIPTION
This will register the following strings from the new search widget(Elementor 2.23):
- Search input placeholder text.
- Search button text.
- No results text.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-520