### PR TITLE
[wcml-4848] Temporary fix for incorrect blocks in WC's refunds policy page

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -82,7 +82,7 @@
 
 	<gutenberg-blocks>
 		<gutenberg-block type="core/paragraph" translate="1">
-			<xpath>//p</xpath>
+			<xpath>//*[self::p or self::h2]</xpath>
 		</gutenberg-block>
 		<gutenberg-block type="core/heading" translate="1">
 			<xpath>//*[self::h1 or self::h2 or self::h3 or self::h4 or self::h5 or self::h6]</xpath>


### PR DESCRIPTION
The refunds policy has incorrect markup on some headings:
```
<!-- wp:paragraph -->
<h2>heading2</h2>
<!-- /wp:paragraph -->
```

This pull request will make sure the above works while [WooCommerce fixes the markup](https://github.com/woocommerce/woocommerce/issues/51618).

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-4848