### PR TITLE
[wcml-4857] Update WooCommerce Product Addons plugin name

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -89,6 +89,7 @@
 		<item id="woocommerce-plivo" override_local="true">WooCommerce Plivo</item>
 		<item id="woocommerce-postepay" override_local="true">WooCommerce PostePay</item>
 		<item id="woocommerce-price-by-country" override_local="true">WooCommerce Price by Country</item>
+		<item id="woocommerce-product-addons" override_local="true">WooCommerce Product Add-Ons</item>
 		<item id="woocommerce-product-addons" override_local="true">WooCommerce Product Add-ons</item>
 		<item id="woocommerce-product-addons" override_local="true">Woo Product Add-ons</item>
 		<item id="woocommerce-product-bundles">WooCommerce Product Bundles</item>

--- a/woocommerce-product-addons/wpml-config.xml
+++ b/woocommerce-product-addons/wpml-config.xml
@@ -1,6 +1,6 @@
 <wpml-config>
 	<custom-fields>
-		<custom-field action="ignore">_product_addons</custom-field>
+		<custom-field action="translate">_product_addons</custom-field>
 		<custom-field action="copy">_product_addons_exclude_global</custom-field>
 	</custom-fields>
 </wpml-config>

--- a/woocommerce-product-addons/wpml-config.xml
+++ b/woocommerce-product-addons/wpml-config.xml
@@ -1,6 +1,6 @@
 <wpml-config>
 	<custom-fields>
-		<custom-field action="translate">_product_addons</custom-field>
+		<custom-field action="ignore">_product_addons</custom-field>
 		<custom-field action="copy">_product_addons_exclude_global</custom-field>
 	</custom-fields>
 </wpml-config>


### PR DESCRIPTION
- The plugin name changed from "Add-ons" to "Add-Ons". I kept both versions for backward compatibility.

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-4857/WPML-4.7-Fix-WooCommerce-Product-Addons-integration