### PR TITLE
[Spectra] Making Info Box Block Title prefix translatable for other HTML tags

### DIFF
--- a/ultimate-addons-for-gutenberg/wpml-config.xml
+++ b/ultimate-addons-for-gutenberg/wpml-config.xml
@@ -18,7 +18,7 @@
 			<key name="ctaText"/>
 		</gutenberg-block>
 		<gutenberg-block type="uagb/info-box" translate="1">
-			<xpath label="Title Prefix">//span[@class="uagb-ifb-title-prefix"]</xpath>
+			<xpath label="Title Prefix">//*[@class="uagb-ifb-title-prefix"]</xpath>
 			<xpath label="Title">//*[@class="uagb-ifb-title"]</xpath>
 			<xpath label="Description">//p[@class="uagb-ifb-desc"]</xpath>
 			<xpath label="Button Text">//span[contains(@class, 'uagb-inline-editing')]</xpath>


### PR DESCRIPTION
- Info Box Block Title prefix was translatable only for <span> tags
- https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7655