### PR TITLE
[wpmlpb-547] Allow translating Previous and Next navigation labels

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -285,5 +285,11 @@
 		<gutenberg-block type="core/social-link" translate="1">
 			<key name="url" type="link" />
 		</gutenberg-block>
+		<gutenberg-block type="core/query-pagination-previous" translate="1">
+			<key name="label" />
+		</gutenberg-block>
+		<gutenberg-block type="core/query-pagination-next" translate="1">
+			<key name="label" />
+		</gutenberg-block>		
 	</gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
Allow translating Previous and Next navigation labels for Patterns https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-547