### PR TITLE
[compsupp-7678] Inner Column Style Background image is not translatable

### DIFF
--- a/uncode/wpml-config.xml
+++ b/uncode/wpml-config.xml
@@ -169,5 +169,17 @@
                 <attribute>subheading</attribute>
             </attributes>
         </shortcode>
+        <shortcode>
+            <tag>vc_column</tag>
+            <attributes>
+                <attribute type="media-ids">back_image</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>vc_column_inner</tag>
+            <attributes>
+                <attribute type="media-ids">back_image</attribute>
+            </attributes>
+        </shortcode>
     </shortcodes>
 </wpml-config>


### PR DESCRIPTION
Using Uncode theme with WPBakery builder; the back_image attribute in the vc_column_inner shortcode is not automatically translated. This leads to the same image displaying across all languages. This Commit will register the background image for both inner  (vc_column_inner) and outer columns (vc_column). 

Youtrack : https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7678