### PR TITLE
[compsupp-7679] Uncode theme - Add translation to column links

### DIFF
--- a/uncode/wpml-config.xml
+++ b/uncode/wpml-config.xml
@@ -169,5 +169,12 @@
                 <attribute>subheading</attribute>
             </attributes>
         </shortcode>
+        <shortcode>
+            <tag>vc_column</tag>
+            <attributes>
+                <attribute encoding="vc_link" type="link">link_to</attribute>
+                <attribute type="link">column_link</attribute>
+            </attributes>
+        </shortcode>
     </shortcodes>
 </wpml-config>


### PR DESCRIPTION
Uncode has an option to add a link to vc_column and make it clickable. 

Youtrack: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7679