### PR TITLE
[compsupp-7678] Uncode: Allow conversion of background images in Inner Column

### DIFF
--- a/uncode/wpml-config.xml
+++ b/uncode/wpml-config.xml
@@ -174,7 +174,15 @@
             <attributes>
                 <attribute encoding="vc_link" type="link">link_to</attribute>
                 <attribute type="link">column_link</attribute>
+                <attribute type="media-ids">back_image</attribute>
+            </attributes>
+        </shortcode>
+        <shortcode>
+            <tag>vc_column_inner</tag>
+            <attributes>
+                <attribute type="media-ids">back_image</attribute>
             </attributes>
         </shortcode>
     </shortcodes>
 </wpml-config>
+


### PR DESCRIPTION
Transposed from https://github.com/OnTheGoSystems/wpml-config/pull/413 (squashed and reformatted the commit message).

https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7678