### PR TITLE
[wcml-4918] Copy the field storing the booking buffer period.

### DIFF
--- a/woocommerce-bookings/wpml-config.xml
+++ b/woocommerce-bookings/wpml-config.xml
@@ -8,7 +8,7 @@
 		<custom-field action="copy">_wc_booking_enable_range_picker</custom-field>
 		<custom-field action="copy">_wc_booking_calendar_display_mode</custom-field>
 		<custom-field action="copy">_wc_booking_qty</custom-field>
-        	<custom-field action="copy">_wc_booking_has_persons</custom-field>
+		<custom-field action="copy">_wc_booking_has_persons</custom-field>
 		<custom-field action="copy">_wc_booking_person_qty_multiplier</custom-field>
 		<custom-field action="copy">_wc_booking_person_cost_multiplier</custom-field>
 		<custom-field action="copy">_wc_booking_min_persons_group</custom-field>
@@ -39,6 +39,7 @@
 		<custom-field action="copy">_wc_booking_block_cost</custom-field>
 		<custom-field action="copy">_wc_booking_has_restricted_days</custom-field>
 		<custom-field action="copy">_wc_booking_restricted_days</custom-field>
+		<custom-field action="copy">_wc_booking_buffer_period</custom-field>
 	</custom-fields>
 	<custom-types>
 		<custom-type translate="1" automatic="0">bookable_person</custom-type>


### PR DESCRIPTION
Besides the field value, WooCommerce Bookings stores the available slots for bookings in specific transients. Those transienmts get cleared when a booking product is edited, but we still need to clear the transients for the product translations.

This should get merged when WCML 5.4.0 gets released - there, we will include the logic to clear translations transients.