### PR TITLE
Gutenberg - Gallery block lightbox image is not replaced

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -92,6 +92,7 @@
 			<xpath label="Button URL" type="link">//a/@href</xpath>
 		</gutenberg-block>
 		<gutenberg-block type="core/image" translate="1">
+			<key type="post-ids" name="id" />
 			<xpath label="Caption">//figure/figcaption</xpath>
 			<xpath label="Title">//figure//img/@title</xpath>
 			<xpath label="Alt Text">//figure//img/@alt</xpath>

--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -92,7 +92,7 @@
 			<xpath label="Button URL" type="link">//a/@href</xpath>
 		</gutenberg-block>
 		<gutenberg-block type="core/image" translate="1">
-			<key type="post-ids" name="id" />
+			<key type="post-ids" sub-type="attachment" name="id" />
 			<xpath label="Caption">//figure/figcaption</xpath>
 			<xpath label="Title">//figure//img/@title</xpath>
 			<xpath label="Alt Text">//figure//img/@alt</xpath>


### PR DESCRIPTION
Adding Media translation support for Gutenberg core/image widget

From: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-12412