### PR TITLE
[Cornestone] Adding support for translating Subheadlines

### DIFF
--- a/cornerstone/wpml-config.xml
+++ b/cornerstone/wpml-config.xml
@@ -267,6 +267,12 @@
             <fields>
                 <field type="Raw content" editor_type="LINE">raw_content</field>
             </fields>           
-        </widget>           
+        </widget>
+        <widget name="headline">
+            <fields>
+                <field type="Headline: Headline">text_content</field>
+                <field type="Headline: Subheadline">text_subheadline_content</field>
+            </fields>
+        </widget>
     </cornerstone-widgets>
 </wpml-config>


### PR DESCRIPTION
- Headline widgets: Adding support for translating Subheadlines
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-582/Cornestone-Subheadlines-are-not-translatable