### PR TITLE
Yoast SEO - Gutenberg blocks translation - wpmltriage-2557

### DIFF
--- a/wordpress-seo/wpml-config.xml
+++ b/wordpress-seo/wpml-config.xml
@@ -64,5 +64,32 @@
 			<key name="breadcrumbs-404crumb" />
 		</key>
 	</admin-texts>
+	<gutenberg-blocks>
+		<gutenberg-block type="yoast/faq-block" translate="1" label="Yoast Faq Block">
+			<key name="questions">
+				<key name="*">
+					<key name="question" />
+					<key name="answer" />
+					<key name="jsonQuestion" />
+					<key name="jsonAnswer" />
+				</key>
+			</key>
+			<xpath label="Question">//div/strong</xpath>
+			<xpath label="Answer">//div/p</xpath>
+		</gutenberg-block>
+		<gutenberg-block type="yoast/how-to-block" translate="1" label="Yoast How to Block">
+			<key name="jsonDescription" />
+			<key name="steps">
+				<key name="*">
+					<key name="name" />
+					<key name="text" />
+					<key name="jsonName" />
+					<key name="jsonText" />
+				</key>
+			</key>
+      			<xpath>//div/p</xpath>
+			<xpath label="Step Title">//div/ol/li/strong</xpath>
+			<xpath label="Step Description">//div/ol/li/p</xpath>
+		</gutenberg-block>
+	</gutenberg-blocks>
 </wpml-config>
-


### PR DESCRIPTION
Yoast introduced Gutenberg blocks, which are already translatable in ATE. However, when opening the translation in the WP editor, a "Block contains unexpected or invalid content" message appears. Clicking the "Attempt recovery" button causes the block to lose its translation. This happens because the block is translated, but not the block attributes. The issue is caused by the mismatch between the block's attributes and its content.

Following Pierre's suggestion, I removed classes where possible to simplify the code and broaden its scope.

_Comes from [#422](https://github.com/OnTheGoSystems/wpml-config/pull/422), resubmission after [#423](https://github.com/OnTheGoSystems/wpml-config/pull/423) was merged._ 