### PR TITLE
[compsupp-7912] - WooCommerce Product Bundles - Layout of the bundled products

### DIFF
--- a/woocommerce-product-bundles/wpml-config.xml
+++ b/woocommerce-product-bundles/wpml-config.xml
@@ -7,5 +7,7 @@
 		<custom-field action="copy">_wc_sw_max_regular_price</custom-field>
 		<custom-field action="copy">_wc_pb_layout_style</custom-field>
 		<custom-field action="copy">_wc_pb_edit_in_cart</custom-field>
+		<custom-field action="copy">_wc_pb_add_to_cart_form_location</custom-field>
+		<custom-field action="copy">_wc_pb_group_mode</custom-field>
 	</custom-fields>
 </wpml-config>


### PR DESCRIPTION
Improve the user experience by by ensuring the `Layout form location` and `Item grouping` fields and are copied to translated products.

https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7912