### PR TITLE
[compsupp-7950] Cornerstone Button > Secondary button text not translatable

### DIFF
--- a/pro/wpml-config.xml
+++ b/pro/wpml-config.xml
@@ -480,6 +480,7 @@
       <fields>
         <field type="Button: Button Text" editor_type="LINE">anchor_text_primary_content</field>
         <field type="Button: Link URL" editor_type="LINK">anchor_href</field>
+        <field type="Button: Secondary Text" editor_type="LINE">anchor_text_secondary_content</field>
       </fields>
     </widget>    
   </cornerstone-widgets>


### PR DESCRIPTION
Improving support for Cornerstone button widget
The Secondary Button Text `anchor_text_secondary_content` is not translatable.

https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-7950

PS: I checked the [cornerstone remote XML](https://github.com/OnTheGoSystems/wpml-config/blob/d1bb06915a0ab9a962405f947bc5bc24ce531a6c/cornerstone/wpml-config.xml#L255) already and it's up-to-date.