### PR TITLE
wpmlsupp-12759 | Adding the WP Post Query Block's "Read more" text

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -291,6 +291,9 @@
 		</gutenberg-block>
 		<gutenberg-block type="core/query-pagination-next" translate="1">
 			<key name="label" />
-		</gutenberg-block>		
+		</gutenberg-block>
+		<gutenberg-block type="core/read-more" translate="1">
+			<key name="content" />
+		</gutenberg-block>
 	</gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
Making the WP Post Query Block's "Read more" text translatable.

From: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-12759