### PR TITLE
compsupp-8042 | Adding Product-Meta widget

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -640,5 +640,15 @@
                 <field type="SVG: Link Label">link>value>label>value</field>
             </fields>
         </widget>
+    	<widget name="woocommerce-product-meta">
+            <fields>
+		<field type="Single Category Caption" editor_type="LINE">category_caption_single</field>
+		<field type="Plural Category Caption" editor_type="LINE">category_caption_plural</field>
+		<field type="Single tag Caption" editor_type="LINE">tag_caption_single</field>
+		<field type="Single tag Caption" editor_type="LINE">tag_caption_plural</field>
+		<field type="SKU Caption" editor_type="LINE">sku_caption</field>
+		<field type="SKU Missing Caption" editor_type="LINE">sku_missing_caption</field>
+            </fields>
+        </widget>
     </elementor-widgets>
 </wpml-config>


### PR DESCRIPTION
Making the Product-Meta Elementor widget translatable.

From: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8042