### PR TITLE
[comp-3831] Update generic config for blocks in Divi namespace

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -616,6 +616,61 @@
                     </key>
                 </key>
             </key>
+            <key name="title">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value" />
+                    </key>
+                    <key name="tablet">
+                        <key name="value" />
+                    </key>
+                    <key name="phone">
+                        <key name="value" />
+                    </key>
+                </key>
+            </key>
+            <key name="content">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value" />
+                    </key>
+                    <key name="tablet">
+                        <key name="value" />
+                    </key>
+                    <key name="phone">
+                        <key name="value" />
+                    </key>
+                </key>
+            </key>
+            <key name="button">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value">
+                            <key name="text" />
+                            <key name="linkUrl" />
+                        </key>
+                    </key>
+                    <key name="tablet">
+                        <key name="value">
+                            <key name="text" />
+                        </key>
+                    </key>
+                    <key name="phone">
+                        <key name="value">
+                            <key name="text" />
+                        </key>
+                    </key>
+                </key>
+            </key>
+            <key name="image">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value">
+                            <key name="url" />
+                        </key>
+                    </key>
+                </key>
+            </key>
         </gutenberg-block>
         <gutenberg-block type="divi/accordion-item" translate="1">
             <key name="title">


### PR DESCRIPTION
We already had a generic configuration, but I updated it to include other common fields.

This fixed the issue related to the blurb block.

Ref: https://onthegosystems.myjetbrains.com/youtrack/issue/comp-3831