### PR TITLE
compsupp-8058 - Elementor - Titles from WC Products widget

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -616,6 +616,13 @@
                 <field type="SKU Missing Caption" editor_type="LINE">sku_missing_caption</field>
             </fields>
         </widget>
+        <widget name="woocommerce-products">
+            <fields>
+                <field type="Related Products Title" editor_type="LINE">products_related_products_title_text</field>
+                <field type="Products Upsells Title" editor_type="LINE">products_upsells_title_text</field>
+                <field type="Products Cross-Sells Title" editor_type="LINE">products_cross_sells_title_text</field>
+            </fields>
+        </widget>
         <!-- WIP: Elementor Editor V4 -->
         <widget name="e-heading">
             <fields>


### PR DESCRIPTION
Adding translation support for the titles in the WooCommerce products widget.

Widget: https://elementor.com/help/woocommerce-products-pro/
Youtrack ticket: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8058