### PR TITLE
[wpmlsupp-12973] Uncode - Allowing HTML tags in heading widget

### DIFF
--- a/uncode/wpml-config.xml
+++ b/uncode/wpml-config.xml
@@ -164,9 +164,9 @@
         <shortcode>
             <tag>vc_custom_heading</tag>
             <attributes>
-                <attribute>text</attribute>
+                <attribute encoding="allow_html_tags">text</attribute>
                 <attribute>link</attribute>
-                <attribute>subheading</attribute>
+                <attribute encoding="allow_html_tags">subheading</attribute>
             </attributes>
         </shortcode>
         <shortcode>


### PR DESCRIPTION
Allowing HTML tags on the heading and subheading attributes from the `vc_custom_heading` widget.

From: [https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-12973](https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-12973)