### PR TITLE
#467 Divi - add missing link field for the icon widget

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -299,6 +299,9 @@
         </shortcode>
         <shortcode>
             <tag>et_pb_icon</tag>
+            <attributes>
+                <attribute type="link">url</attribute>
+            </attributes>
         </shortcode>        
         <shortcode>
             <tag>et_pb_code</tag>


### PR DESCRIPTION
Closes #467 

https://github.com/OnTheGoSystems/wpml-config/issues/467