### PR TITLE
Image Caption is not translatable

### DIFF
--- a/ultimate-addons-for-gutenberg/wpml-config.xml
+++ b/ultimate-addons-for-gutenberg/wpml-config.xml
@@ -129,6 +129,9 @@
 		</gutenberg-block>
 		<gutenberg-block type="uagb/container" translate="1">
 			<xpath label="Container link" type="link">//a[contains(@class, "spectra-container-link-overlay")]/@href</xpath>
-		</gutenberg-block>		
+		</gutenberg-block>
+		<gutenberg-block type="uagb/image-gallery" translate="1">
+			<key name="imageDefaultCaption" />
+		</gutenberg-block>
 	</gutenberg-blocks>
 </wpml-config>


### PR DESCRIPTION
Spectra - Ultimate Addons for Gutenberg
Make the Image caption translatable in ATE for the "Image with caption (Spectra)" block.

https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8089