### PR TITLE
Missing vc_media_grid in translations - wpmlsupp-12987

### DIFF
--- a/js_composer/wpml-config.xml
+++ b/js_composer/wpml-config.xml
@@ -5,7 +5,7 @@
         <custom-type translate="1">vc_grid_item</custom-type>
     </custom-types>
     <custom-fields>
-        <custom-field action="ignore">_vc_post_settings</custom-field>
+        <custom-field action="copy">_vc_post_settings</custom-field>
         <custom-field action="copy">_wpb_shortcodes_custom_css</custom-field>
         <custom-field action="translate" encoding="json">_wpb_post_custom_seo_settings</custom-field>
     </custom-fields>


### PR DESCRIPTION
WPBakery stores grid shortcode data in the post‑meta `_vc_post_settings`

```
array (
  0 => 
  array (
    'vc_grid_id' => 
    array (
      'shortcodes' => 
      array (
        '1752692542765-444b9747-baac-1' => 
        array (
          'tag' => 'vc_media_grid',
          'atts' => 
          array (
            'css' => '',
            'initial_loading_animation' => 'none',
            'grid_id' => 'vc_gid:1752692542765-444b9747-baac-1',
            'include' => '95758,95757,95756',
          ),
          'content' => '',
        ),
      ),
    ),
  ),
)
```

Since the translation preference of this fields was set as "ignore", translations won’t have it.

Coming from: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlsupp-12987