### PR TITLE
[Divi 5] Adding Product ID's translation in the Namespace

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -666,6 +666,13 @@
                         <key name="value" />
                     </key>
                 </key>
+                <key name="advanced">
+                    <key name="product">
+                        <key name="*">
+                            <key name="value" type="post-ids" sub-type="product" />
+                        </key>
+                    </key>
+                </key>                
             </key>
             <key name="button">
                 <key name="innerContent">


### PR DESCRIPTION
Adding the Product ID's translation in the Namespace. This shouldn't affect other blocks as it is exclusive for products.
https://onthegosystems.myjetbrains.com/youtrack/issue/comp-4205/Divi-5-First-batch-of-WooCommerce-Modules