### PR TITLE
[wcml-5172] Support new plugin name for WCML

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -86,6 +86,7 @@
 		<item id="woocommerce-mix-and-match-products" override_local="true">WooCommerce Mix and Match</item>
 		<item id="woocommerce-multilingual" override_local="true">WooCommerce Multilingual</item>
 		<item id="woocommerce-multilingual" override_local="true">WooCommerce Multilingual &amp; Multicurrency</item>
+		<item id="woocommerce-multilingual" override_local="true">WPML Multilingual &amp; Multicurrency for WooCommerce</item>
 		<item id="woocommerce-name-your-price" override_local="true">WooCommerce Name Your Price</item>
 		<item id="woocommerce-paymill-gateway" override_local="true">WooCommerce Paymill Gateway</item>
 		<item id="woocommerce-pdf-invoices-packing-slips" override_local="true">WooCommerce PDF Invoices &amp; Packing Slips</item>


### PR DESCRIPTION
- Old name (still supported): "WooCommerce Multilingual &amp; Multicurrency"
- New name: "WPML Multilingual & Multicurrency for WooCommerce"

https://onthegosystems.myjetbrains.com/youtrack/issue/wcml-5172/