### PR TITLE
[compsupp-8149] Avada Title widget links not updated on translations

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -567,6 +567,7 @@
 				<attribute>after_text</attribute>
 				<attribute>animated_text</attribute>
 				<attribute>rotation_text</attribute>
+				<attribute type="link">link_url</attribute>
 			</attributes>
 		</shortcode>
 		<shortcode>


### PR DESCRIPTION
Avada Title widget’s link field doesn't auto-translate internal links. Links on the translated page still point to the default language URL.

https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8149