### PR TITLE
[wpmlpb-655] Divi 5: allow translating global variables (strings)

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -57,6 +57,13 @@
             <key name="divi_seo_home_keywordstext"/>
             <key name="custom_footer_credits"/>
         </key>
+        <key name="et_divi_global_variables">
+            <key name="strings">
+                <key name="*">
+                    <key name="value" />
+                </key>
+            </key>
+        </key>
     </admin-texts>
     <shortcodes>
         <shortcode>


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-655/Divi-5-Global-variables-are-not-translating-correctly-with-WPML.