### PR TITLE
[wpmlpb-689] Add support for media-url in block attributes

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -631,7 +631,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link" />
+                                    <key name="url" type="media-url" />
                                 </key>
                                 <key name="video">
                                     <key name="mp4" />
@@ -764,7 +764,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link"/>
+                                    <key name="url" type="media-url"/>
                                 </key>
                             </key>
                         </key>
@@ -1195,7 +1195,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link" />
+                                    <key name="url" type="media-url" />
                                 </key>
                             </key>
                         </key>
@@ -1229,7 +1229,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link" />
+                                    <key name="url" type="media-url" />
                                 </key>
                             </key>
                         </key>
@@ -1251,7 +1251,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link" />
+                                    <key name="url" type="media-url" />
                                 </key>
                             </key>
                         </key>
@@ -1266,7 +1266,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link" />
+                                    <key name="url" type="media-url" />
                                 </key>
                             </key>
                         </key>
@@ -1370,7 +1370,7 @@
                         <key name="*">
                             <key name="value">
                                 <key name="image">
-                                    <key name="url" type="link"/>
+                                    <key name="url" type="media-url"/>
                                 </key>
                             </key>
                         </key>


### PR DESCRIPTION
To be included in WPML Multilingual CMS 4.9

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-689/