### PR TITLE
[wpmlpb-665] Avada: translatable form notifications

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -224,6 +224,16 @@
 			<key name="button_1" />
 			<key name="button_2" />
 			<key name="vimeo_id" />
+			<key name="notifications">
+				<key name="*">
+					<key name="label" />
+					<key name="email_subject" />
+					<key name="email_from" />
+					<key name="email_from_id" />
+					<key name="email_reply_to" />
+					<key name="email_message" />
+				</key>
+			</key>
 		</key>
 	</custom-fields-texts>
 	<custom-term-fields>


### PR DESCRIPTION
We will merge these XML changes with WPML 4.10.

This will give time to existing Avada users to update to 4.9 which will apply this XML configuration via code. 

When we release 4.10, all users should have the updates required for this XML to work and we can remove the code thats applies this configuration and use the XML instead.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-665