### PR TITLE
compsupp-8329 - Divi 5 - Extend Contact Form XML

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -1033,6 +1033,26 @@
                         <key name="value" />
                     </key>
                 </key>
+                <key name="advanced">
+                    <key name="radioOptions">
+                        <key name="*">
+                            <key name="value">
+                                <key name="*">
+                                    <key name="value" />
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                    <key name="checkboxOptions">
+                        <key name="*">
+                            <key name="value">
+                                <key name="*">
+                                    <key name="value" />
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                </key>
             </key>
         </gutenberg-block>
         <gutenberg-block type="divi/contact-form" translate="1">


### PR DESCRIPTION
Contact Form Block - Add advanced options for radio and checkbox option fields.

Ref: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8329