### PR TITLE
[compsupp-8352] Add configuration for Divi shop block

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -1399,6 +1399,19 @@
                 </key>
             </key>
         </gutenberg-block>
+        <gutenberg-block type="divi/shop" translate="0">
+            <key name="content">
+                <key name="advanced">
+                    <key name="includeCategories">
+                        <key name="*">
+                            <key name="value">
+                                <key name="*" type="taxonomy-ids" sub-type="product_cat" />
+                            </key>
+                        </key>
+                    </key>
+                </key>
+            </key>
+        </gutenberg-block>
         <gutenberg-block type="divi/gallery" translate="1">
             <key name="image">
                 <key name="advanced">


### PR DESCRIPTION
Added config for the Divi 5 shop block to translate product categories automatically.

Divi Woo Products module was not filtering product categories correctly. 

Ref: https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8352