### PR TITLE
[wpmlpb-828] - Media Translation not supported under a wildcard.

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -787,8 +787,26 @@
             </key>
             <key name="image">
                 <key name="innerContent">
-                    <key name="*">
-                        <key name="*">
+                    <key name="desktop">
+                        <key name="value">
+                            <key type="media-ids" name="id" />
+                            <key type="media-url" name="src" />
+                            <key name="alt" />
+                            <key name="titleText" />
+                            <key type="link" name="linkUrl" />
+                        </key>
+                    </key>
+                    <key name="tablet">
+                        <key name="value">
+                            <key type="media-ids" name="id" />
+                            <key type="media-url" name="src" />
+                            <key name="alt" />
+                            <key name="titleText" />
+                            <key type="link" name="linkUrl" />
+                        </key>
+                    </key>
+                    <key name="phone">
+                        <key name="value">
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
                             <key name="alt" />
@@ -802,7 +820,25 @@
         <gutenberg-block type="divi/menu" translate="1">
             <key name="logo">
                 <key name="innerContent">
-                    <key name="*">
+                    <key name="desktop">
+                        <key name="value">
+                            <key type="media-ids" name="id" />
+                            <key type="media-url" name="src" />
+                            <key name="alt" />
+                            <key name="titleText" />
+                            <key type="link" name="linkUrl" />
+                        </key>
+                    </key>
+                    <key name="tablet">
+                        <key name="value">
+                            <key type="media-ids" name="id" />
+                            <key type="media-url" name="src" />
+                            <key name="alt" />
+                            <key name="titleText" />
+                            <key type="link" name="linkUrl" />
+                        </key>
+                    </key>
+                    <key name="phone">
                         <key name="value">
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
@@ -1416,7 +1452,13 @@
             <key name="image">
                 <key name="advanced">
                     <key name="galleryIds">
-                        <key name="*">
+                        <key name="desktop">
+                            <key name="value" type="media-ids" />
+                        </key>
+                        <key name="tablet">
+                            <key name="value" type="media-ids" />
+                        </key>
+                        <key name="phone">
                             <key name="value" type="media-ids" />
                         </key>
                     </key>


### PR DESCRIPTION
It seems that the newly added types `media-ids` and `media-urls` are not supported under a wildcard. I replaced the wild card with the three possible values `desktop`, `tablet`, `phone`.

The issue was reported for the Image block, but I updated two other blocks with the same configuration: `divi/menu` and `divi/gallery`.

Ref: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-828/Divi-5-Media-Translation-displays-the-original-image