### PR TITLE
[wpmlpb-847] Mark core/group Gutenberg block as not translatable

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -171,6 +171,7 @@
 		<gutenberg-block type="wpml/language-switcher" translate="0" />
 		<gutenberg-block type="wpml/navigation-language-switcher" translate="0" />
 		<gutenberg-block type="core/columns" translate="0" />
+		<gutenberg-block type="core/group" translate="0" />
 		<gutenberg-block type="core/code" translate="0" />
 		<gutenberg-block type="core/more" translate="0" />
 		<gutenberg-block type="core/nextpage" translate="0" />


### PR DESCRIPTION
https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-847/