### PR TITLE
[comp-4504] Setting Custom Layouts to Copy  _wpb_post_custom_layout

### DIFF
--- a/js_composer/wpml-config.xml
+++ b/js_composer/wpml-config.xml
@@ -7,6 +7,7 @@
     <custom-fields>
         <custom-field action="ignore">_vc_post_settings</custom-field>
         <custom-field action="copy">_wpb_shortcodes_custom_css</custom-field>
+        <custom-field action="copy">_wpb_post_custom_layout</custom-field>
         <custom-field action="translate" encoding="json">_wpb_post_custom_seo_settings</custom-field>
     </custom-fields>
     <shortcodes>


### PR DESCRIPTION
Setting `_wpb_post_custom_layout` custom field as copy for WPBakery 9.0
https://onthegosystems.myjetbrains.com/youtrack/issue/comp-4504