### PR TITLE
[wpmlpb-828] Divi 5 image: restore wildcard media config, drop titleText

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -813,7 +813,6 @@
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
                             <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>
@@ -822,7 +821,6 @@
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
                             <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>
@@ -831,7 +829,6 @@
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
                             <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>


### PR DESCRIPTION
Drop the image innerContent titleText key: Divi renders the image title from the module decoration "Image Title" attribute, not from innerContent titleText, so that key never surfaced a translatable string.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-828/