### PR TITLE
[wpmlpb-759] Type Divi image url/src as media-url

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -677,7 +677,7 @@
                 <key name="innerContent">
                     <key name="*">
                         <key name="value">
-                            <key name="url" />
+                            <key name="url" type="media-url" />
                         </key>
                     </key>
                 </key>
@@ -954,7 +954,7 @@
                 <key name="innerContent">
                     <key name="*">
                         <key name="value">
-                            <key name="src" />
+                            <key name="src" type="media-url" />
                         </key>
                     </key>
                 </key>
@@ -1034,7 +1034,7 @@
                 <key name="innerContent">
                     <key name="*">
                         <key name="value">
-                            <key name="url" />
+                            <key name="url" type="media-url" />
                         </key>
                     </key>
                 </key>


### PR DESCRIPTION
Retype remaining image url/src keys in the Divi gutenberg-block config from `link`/untyped to `media-url`.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-759/