### PR TITLE
[wpmlpb-857] divi/menu: capture rendered logo title/alt from decoration

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -847,14 +847,27 @@
             </key>
         </gutenberg-block>
         <gutenberg-block type="divi/menu" translate="1">
+            <key name="module">
+                <key name="decoration">
+                    <key name="attributes">
+                        <key name="*">
+                            <key name="value">
+                                <key name="attributes">
+                                    <key name="*">
+                                        <key name="value" />
+                                    </key>
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                </key>
+            </key>
             <key name="logo">
                 <key name="innerContent">
                     <key name="desktop">
                         <key name="value">
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
-                            <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>
@@ -862,8 +875,6 @@
                         <key name="value">
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
-                            <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>
@@ -871,8 +882,6 @@
                         <key name="value">
                             <key type="media-ids" name="id" />
                             <key type="media-url" name="src" />
-                            <key name="alt" />
-                            <key name="titleText" />
                             <key type="link" name="linkUrl" />
                         </key>
                     </key>


### PR DESCRIPTION
Divi renders the menu logo title/alt from the module decoration attributes (targetElement="logo"), but the config only captured the non-rendered logo>innerContent alt/titleText copies - so translating them had no front-end effect. Add the module>decoration>attributes>* capture (as divi/image already has) and drop the dead logo>innerContent alt/titleText.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-857/