### PR TITLE
[wpmlpb-824] Divi: translate contact-field conditional-logic and select-options

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -1248,6 +1248,26 @@
                             </key>
                         </key>
                     </key>
+                    <key name="selectOptions">
+                        <key name="*">
+                            <key name="value">
+                                <key name="*">
+                                    <key name="value" />
+                                </key>
+                            </key>
+                        </key>
+                    </key>
+                </key>
+            </key>
+            <key name="conditionalLogic">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value">
+                            <key name="*">
+                                <key name="value" />
+                            </key>
+                        </key>
+                    </key>
                 </key>
             </key>
         </gutenberg-block>


### PR DESCRIPTION
Contact form fields with conditional logic ("show if Field = Value") stopped working on translated pages: the option labels were translated but the rule's compared value was not, so Divi's strict string match ("is") no longer succeeded and the dependent field never showed.

Register the conditionalLogic rule values so both the option and the rule translate to the same string (they share one WPML string, so they cannot diverge) and the match holds after translation. Also add the previously missing selectOptions, so select-field options translate too -- otherwise translating a select-based rule value would newly break the match.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-824/