### PR TITLE
[wpmlpb-841] Elementor: translate atomic image (e-image) alt text

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -756,6 +756,7 @@
             <fields>
                 <field type="Image: Link URL" editor_type="LINK">link>value>destination>value</field>
                 <field type="Image: Link Label">link>value>label>value</field>
+                <field type="Image: Alt">image>value>src>value>alt>value</field>
             </fields>
         </widget>
         <widget name="e-svg">


### PR DESCRIPTION
Register the atomic image widget's stored alt (image>value>src>value>alt>value) as a translatable string so it is picked up for translation. This covers URL-based atomic images, whose rendered alt comes from the widget.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-841/