### PR TITLE
[wpmlpb-834] Add the Elementor atomic Select form widget

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -806,6 +806,11 @@
         </widget>
         <widget name="e-form-file-upload">
         </widget>
+        <widget name="e-form-select">
+            <fields-in-item items_of="options>value">
+                <field type="Form Select: Option Label" editor_type="LINE">value>key>value</field>
+            </fields-in-item>
+        </widget>
         <widget name="e-form-submit-button">
             <fields>
                 <field type="Form: Submit Button">label>value</field>


### PR DESCRIPTION
Registers the option labels of the atomic Select widget (e-form-select) for translation. Its options are a non-associative list at options>value, each a key-value entry whose key holds the visible label; requires the WPML Page Builders release with fields-in-item support for nested items fields.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-834