### PR TITLE
[comp-4504] Delegate wpml-config.xml ownership to Spectra team

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -60,8 +60,8 @@
 		<item id="stackable-ultimate-gutenberg-blocks" override_local="true">Stackable - Gutenberg Blocks (Premium)</item>
 		<item id="subscriptio">Subscriptio</item>
 		<item id="the-events-calendar" override_local="true">The Events Calendar</item>
-		<item id="ultimate-addons-for-gutenberg" override_local="true">Ultimate Addons for Gutenberg</item>
-		<item id="ultimate-addons-for-gutenberg" override_local="true">Spectra</item>
+		<item id="ultimate-addons-for-gutenberg" override_local="false">Ultimate Addons for Gutenberg</item>
+		<item id="ultimate-addons-for-gutenberg" override_local="false">Spectra</item>
 		<item id="ultimate-member" override_local="true">Ultimate Member</item>
 		<item id="uncode-js_composer" override_local="true">Uncode Page Builder (Visual Composer)</item>
 		<item id="uncode-js_composer" override_local="true">Uncode WPBakery Page Builder</item>


### PR DESCRIPTION
Set `override_local` to `false` and delegate the XML ownership to the Spectra team: https://onthegosystems.myjetbrains.com/youtrack/issue/comp-4508