### PR TITLE
[comp-4499] Elementor 4.2: make atomic form (e-form) Email 1 & Email 2 notification translatable

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -783,6 +783,10 @@
         <widget name="e-form">
             <fields>
                 <field type="Form: Name">form-name</field>
+                <field type="Form: Email subject">email>value>subject>value</field>
+                <field type="Form: Email Content" editor_type="AREA">email>value>message>value</field>
+                <field type="Form: Email subject 2">email_2>value>subject>value</field>
+                <field type="Form: Email Content 2" editor_type="AREA">email_2>value>message>value</field>
             </fields>
         </widget>
         <widget name="e-form-label">


### PR DESCRIPTION
The atomic form element (e-form) stores its email-action settings as Emails_Prop_Type object props (email, and email_2 enabled by Elementor Pro), each holding subject + message string sub-props. Only 'form-name' was registered, so the email subject/message were not offered for translation -- a regression versus the classic 'form' widget, which already exposes email_subject/email_content/email_subject_2/email_content_2.

Register the nested paths so both notifications become translatable:
  email>value>subject>value, email>value>message>value,
  email_2>value>subject>value, email_2>value>message>value

Verified on Elementor 4.2.0-beta2 + Pro: WPML string extraction for an e-form node goes from 0 to 4 strings with this change.

https://onthegosystems.myjetbrains.com/youtrack/issue/comp-4499