### PR TITLE
Register woocommerce-warranty in config-index.xml

### DIFF
--- a/config-index.xml
+++ b/config-index.xml
@@ -103,6 +103,8 @@
 		<item id="woocommerce-social-media-share-buttons" override_local="true">Woocommerce Social Media Share Buttons</item>
 		<item id="woocommerce-tab-manager" override_local="true">WooCommerce Tab Manager</item>
 		<item id="woocommerce-video-tab" override_local="true">WooCommerce Video Tab</item>
+		<item id="woocommerce-warranty" override_local="true">WooCommerce Warranty Requests</item>
+		<item id="woocommerce-warranty" override_local="true">Warranty Requests</item>
 		<item id="wordpress-seo" override_local="true">Yoast SEO</item>
 		<item id="wordpress-seo" override_local="true">Yoast SEO Premium</item>
 		<item id="wp-job-manager">WP Job Manager</item>


### PR DESCRIPTION
Summary: Registers the existing woocommerce-warranty/wpml-config.xml in the index so WPML actually serves it.

  Problem: The config has shipped since 2017 (commit cdb66d7) but was never added to config-index.xml — so it has never been served.

  Change: Two <item id="woocommerce-warranty"> alias lines (WooCommerce Warranty Requests + Warranty Requests), placed alphabetically after
  woocommerce-video-tab, with override_local="true" to match every other woocommerce-* entry.

  Risk: None — registration only; no translate/copy values authored.

  Verified: schema passes · build-index resolves the entry · orphan count 1 → 0.