### PR TITLE
[wpmlpb-795] Exclude the core/math block from translation

### DIFF
--- a/sitepress-multilingual-cms/wpml-config.xml
+++ b/sitepress-multilingual-cms/wpml-config.xml
@@ -173,6 +173,7 @@
 		<gutenberg-block type="core/columns" translate="0" />
 		<gutenberg-block type="core/group" translate="0" />
 		<gutenberg-block type="core/code" translate="0" />
+		<gutenberg-block type="core/math" translate="0" />
 		<gutenberg-block type="core/more" translate="0" />
 		<gutenberg-block type="core/nextpage" translate="0" />
 		<gutenberg-block type="core/separator" translate="0" />


### PR DESCRIPTION
YouTrack: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-795/

Syncs the central config repo with the product fix in sitepress-multilingual-cms MR !5988 (git.onthegosystems.com/wpml/sitepress-multilingual-cms/-/merge_requests/5988).

**Problem:** The Gutenberg Math block (core/math, added in WP 6.9) had no wpml-config.xml entry, so WPML registered its entire rendered MathML tree as one VISUAL string, which the Advanced Translation Editor then split into one translation unit per MathML token — far too many trans units for a trivial formula.

**Fix:** Mark core/math as non-translatable in sitepress-multilingual-cms/wpml-config.xml (same handling as core/code), so no strings are extracted from it.