### PR TITLE
Elementor: remove duplicate _elementor_edit_mode custom-field

### DIFF
--- a/elementor/wpml-config.xml
+++ b/elementor/wpml-config.xml
@@ -6,7 +6,6 @@
         <custom-field action="copy">_elementor_version</custom-field>
         <custom-field action="copy-once">_elementor_data</custom-field>
         <custom-field action="ignore">_elementor_css</custom-field>
-        <custom-field action="copy">_elementor_edit_mode</custom-field>
         <custom-field action="copy-once">_elementor_popup_display_settings</custom-field>
     </custom-fields>
     <custom-types>


### PR DESCRIPTION
**Summary:** Removes a duplicated custom-field from the Elementor config — the config's only genuine duplicate.

**Problem:** `_elementor_edit_mode` (`action="copy"`) appears twice in the `<custom-fields>` block (lines 4 and 9).

**Change:** Deletes the redundant second occurrence (line 9), keeping the first (line 4).

**Risk:** None — identical entries. The two `url` fields in the `media-carousel` widget look similar but are **not** duplicates (different `key_of`: `video` vs `image_link_to`, translating two distinct links), so they are intentionally left untouched.

**Verified:** schema passes · build-index passes · key now appears once · diff is one deletion.
