### PR TITLE
Divi / Divi Builder: remove duplicate _et_pb_show_page_creation custom-field

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -45,7 +45,6 @@
         <custom-field action="copy">_et_pb_ab_testing_id</custom-field>
         <custom-field action="copy">_et_pb_ab_subjects</custom-field>
         <custom-field action="copy">_et_pb_ab_goal_module</custom-field>
-        <custom-field action="copy">_et_pb_show_page_creation</custom-field>
         <custom-field action="copy">_et_pb_excluded_global_options</custom-field>
         <custom-field action="copy-once">et_pb_post_hide_nav</custom-field>
         <custom-field action="copy">_et_pb_use_divi_5</custom-field>

--- a/divi-builder/wpml-config.xml
+++ b/divi-builder/wpml-config.xml
@@ -44,7 +44,6 @@
         <custom-field action="copy">_et_pb_ab_testing_id</custom-field>
         <custom-field action="copy">_et_pb_ab_subjects</custom-field>
         <custom-field action="copy">_et_pb_ab_goal_module</custom-field>
-        <custom-field action="copy">_et_pb_show_page_creation</custom-field>
         <custom-field action="copy">_et_pb_excluded_global_options</custom-field>
         <custom-field action="copy-once">et_pb_post_hide_nav</custom-field>
     </custom-fields>


### PR DESCRIPTION
**Summary:** Removes a duplicated custom-field that appears in both the Divi theme and the Divi Builder plugin configs.

**Problem:** `_et_pb_show_page_creation` (`action="copy"`) is listed twice in the `<custom-fields>` block of both `Divi/wpml-config.xml` and `divi-builder/wpml-config.xml` — a copy-paste carried across the two sibling configs.

**Change:** Deletes the redundant second occurrence in each file (one commit, two files).

**Risk:** None — the two entries are byte-identical, so the field stays registered once with the same action; applying an identical directive once instead of twice yields the same result.

**Verified:** schema passes · build-index passes · each file lists the key once · diff is two deletions.