### PR TITLE
[compdev-1364] Make a false value actually false

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There are a couple of requisites:
 - The XML entry has to be inside one of these elements: `<plugins>` or `<themes>`
 - The id attribute in the index file corresponds to the folder name and must match the folder name of the plugin or theme.
 - The name of the plugin has to match the name of the plugin in its header.
+- The optional `override_local` attribute accepts `"true"` or `"false"` (the default when omitted). When `"true"`, the configuration in this repository replaces the plugin's or theme's bundled `wpml-config.xml`; otherwise the bundled file stays active. Any other value makes `bin/update` fail.
 
 For example:
 

--- a/bin/update
+++ b/bin/update
@@ -20,7 +20,8 @@ class WPML_Config_Index {
 	function update() {
 		$this->load_xml();
 		if ( ! $this->validate_paths() ) {
-			die( implode( PHP_EOL, $this->errors ) . PHP_EOL );
+			fwrite( STDERR, implode( PHP_EOL, $this->errors ) . PHP_EOL );
+			exit( 1 );
 		}
 		$this->save_json();
 	}
@@ -46,6 +47,11 @@ class WPML_Config_Index {
 			$path = $slug . '/wpml-config.xml';
 			if ( ! file_exists( $path ) ) {
 				$errors[] = "File <$path> not found.";
+			}
+
+			$override_local = $config->attributes()['override_local'];
+			if ( null !== $override_local && ! in_array( (string) $override_local, array( 'true', 'false' ), true ) ) {
+				$errors[] = "Invalid override_local=\"$override_local\" for <$slug>: use \"true\", \"false\", or omit the attribute.";
 			}
 		}
 
@@ -73,7 +79,7 @@ class WPML_Config_Index {
 		$name = (string) $item;
 		$slug = (string) $item->attributes()['id'];
 		$path = $slug . '/wpml-config.xml';
-		$override_local = (bool) $item->attributes()['override_local'];
+		$override_local = 'true' === (string) $item->attributes()['override_local'];
 
 		$data = new stdClass;
 		$data->name = $name;


### PR DESCRIPTION
The attribute was cast with (bool), so the documented "false" value was silently truthy and the only working way to disable overriding was to omit the attribute. Parse "true" strictly, reject any value other than "true"/"false" at build time, and report validation failures on STDERR with a non-zero exit code so CI fails (die exits with 0).

https://onthegosystems.myjetbrains.com/youtrack/issue/compdev-1364