### PR TITLE
Avada: remove duplicate entries

### DIFF
--- a/avada/wpml-config.xml
+++ b/avada/wpml-config.xml
@@ -1,6 +1,6 @@
 <wpml-config>
 	<built-with-page-builder>/\[(fusion_builder_container|fusion_builder_row|fusion_builder_row_inner|fusion_builder_column|fusion_builder_column_inner)/</built-with-page-builder>
-	<shortcode-list>fusion_alert,fusion_blog,fusion_button,fusion_checklist,fusion_li_item,fusion_code,fusion_builder_row,fusion_builder_row_inner,fusion_builder_column,fusion_builder_column_inner,fusion_builder_container,fusion_content_boxes,fusion_content_box,fusion_countdown,fusion_counters_box,fusion_counter_box,fusion_counters_circle,fusion_counter_circle,fusion_dropcap,fusion_events,fusion_faq,fusion_flip_boxes,fusion_flip_box,fusion_fontawesome,fusion_fusionslider,fusion_map,fusion_images,fusion_image,fusion_imageframe,layerslider,fusion_lightbox,fusion_menu_anchor,fusion_modal,fusion_modal_text_link,fusion_one_page_text_link,fusion_person,fusion_popover,fusion_popover,fusion_portfolio,fusion_postslider,fusion_pricing_table,fusion_pricing_column,fusion_pricing_price,fusion_pricing_row,fusion_pricing_footer,fusion_progress,fusion_recent_posts,rev_slider,fusion_section_separator,fusion_separator,fusion_sharing,fusion_slider,fusion_slide,fusion_social_links,fusion_soundcloud,fusion_soundcloud,fusion_tabs,fusion_tab,fusion_tagline_box,fusion_testimonials,fusion_testimonial,fusion_text,fusion_title,fusion_accordion,fusion_toggle,fusion_tooltip,fusion_login,fusion_lost_password,fusion_register,fusion_vimeo,fusion_widget_area,fusion_products_slider,fusion_featured_products_slider,fusion_youtube,fusion_tb_author,fusion_tb_comments,fusion_tb_content,fusion_tb_featured_slider,fusion_tb_pagination,fusion_tb_related,fusion_tb_results,fusion_tb_project_details,fusion_contact_form,fusion_privacy,fusion_audio,fusion_breadcrumbs,fusion_convert_plus,fusion_highlight,fusion_search,fusion_syntax_highlighter,fusion_video,fusion_widget,fusion_form,fusion_circle_info</shortcode-list>
+	<shortcode-list>fusion_alert,fusion_blog,fusion_button,fusion_checklist,fusion_li_item,fusion_code,fusion_builder_row,fusion_builder_row_inner,fusion_builder_column,fusion_builder_column_inner,fusion_builder_container,fusion_content_boxes,fusion_content_box,fusion_countdown,fusion_counters_box,fusion_counter_box,fusion_counters_circle,fusion_counter_circle,fusion_dropcap,fusion_events,fusion_faq,fusion_flip_boxes,fusion_flip_box,fusion_fontawesome,fusion_fusionslider,fusion_map,fusion_images,fusion_image,fusion_imageframe,layerslider,fusion_lightbox,fusion_menu_anchor,fusion_modal,fusion_modal_text_link,fusion_one_page_text_link,fusion_person,fusion_popover,fusion_portfolio,fusion_postslider,fusion_pricing_table,fusion_pricing_column,fusion_pricing_price,fusion_pricing_row,fusion_pricing_footer,fusion_progress,fusion_recent_posts,rev_slider,fusion_section_separator,fusion_separator,fusion_sharing,fusion_slider,fusion_slide,fusion_social_links,fusion_soundcloud,fusion_tabs,fusion_tab,fusion_tagline_box,fusion_testimonials,fusion_testimonial,fusion_text,fusion_title,fusion_accordion,fusion_toggle,fusion_tooltip,fusion_login,fusion_lost_password,fusion_register,fusion_vimeo,fusion_widget_area,fusion_products_slider,fusion_featured_products_slider,fusion_youtube,fusion_tb_author,fusion_tb_comments,fusion_tb_content,fusion_tb_featured_slider,fusion_tb_pagination,fusion_tb_related,fusion_tb_results,fusion_tb_project_details,fusion_contact_form,fusion_privacy,fusion_audio,fusion_breadcrumbs,fusion_convert_plus,fusion_highlight,fusion_search,fusion_syntax_highlighter,fusion_video,fusion_widget,fusion_form,fusion_circle_info</shortcode-list>
 	<admin-texts>
 		<key name="fusion_options">
 			<key name="header_number"/>
@@ -21,11 +21,7 @@
 			<key name="email_address"/>
 			<key name="contact_form_privacy_label"/>
 			<key name="gmap_address"/>
-			<key name="email_address"/>
-			<key name="blog_subtitle"/>
-			<key name="date_format"/>
 			<key name="map_infobox_content"/>
-			<key name="sharing_social_tagline"/>
 			<key name="privacy_bar_text"/>
 			<key name="privacy_bar_button_text" />
 			<key name="privacy_bar_more_text"/>
@@ -149,7 +145,6 @@
 		<custom-field action="copy-once">pyre_page_title_100_width</custom-field>
 		<custom-field action="copy-once">pyre_page_title_breadcrumbs_search_bar</custom-field>
 		<custom-field action="copy-once">pyre_page_title_text_alignment</custom-field>
-		<custom-field action="translate">pyre_project_url_text</custom-field>
 		<custom-field action="translate">pyre_heading</custom-field>
 		<custom-field action="translate">pyre_caption</custom-field>
 		<custom-field action="copy-once">pyre_type</custom-field>
@@ -701,9 +696,6 @@
 				<attribute label="Gallery Image: Title">image_title</attribute>
 				<attribute label="Gallery Image: Caption">image_caption</attribute>
 			</attributes>
-		</shortcode>
-		<shortcode>
-			<tag>fusion_dropcap</tag>
 		</shortcode>
 		<shortcode>
 			<tag>fusion_video</tag>


### PR DESCRIPTION
**Summary:** Consolidates several duplicated entries across the Avada config into single occurrences.

**Problem:** Multiple entries are listed twice: custom-field `pyre_project_url_text` (`action="translate"`); the `fusion_dropcap` `<shortcode>` definition; four admin-text keys under `fusion_options` (`email_address`, `blog_subtitle`, `date_format`, `sharing_social_tagline`); and two `<shortcode-list>` items (`fusion_popover`, `fusion_soundcloud`).

**Change:** Removes the redundant second occurrence of each. The `fusion_dropcap` reference inside `<shortcode-list>` is a separate, valid registration and is kept.

**Risk:** None — every removal keeps one identical entry.

**Verified:** schema passes · build-index passes · each item appears once · diff is removals only.