### PR TITLE
Brooklyn: remove duplicate shortcode definitions

### DIFF
--- a/brooklyn/wpml-config.xml
+++ b/brooklyn/wpml-config.xml
@@ -110,18 +110,6 @@
             <tag>ut_service_box</tag>
         </shortcode>
         <shortcode>
-            <tag>ut_service_column</tag>
-            <attributes>
-                <attribute>headline</attribute>
-            </attributes>
-        </shortcode>
-        <shortcode>
-            <tag>ut_service_column_vertical</tag>
-            <attributes>
-                <attribute>headline</attribute>
-            </attributes>
-        </shortcode>
-        <shortcode>
             <tag>ut_service_icon_box</tag>
             <attributes>
                 <attribute>headline</attribute>


### PR DESCRIPTION
**Summary:** Removes two fully duplicated `<shortcode>` blocks from the Brooklyn theme config.

**Problem:** `ut_service_column` and `ut_service_column_vertical` are each defined twice with an identical tag and `<attribute>headline</attribute>`.

**Change:** Deletes the redundant second `<shortcode>` block for each (12 lines total).

**Risk:** None — identical definitions; each shortcode stays registered once with the same attributes.

**Verified:** schema passes · build-index passes · each shortcode defined once · diff is 12 deletions.