### PR TITLE
WooCommerce Composite Products: remove duplicate _bto_selection_mode custom-field

### DIFF
--- a/woocommerce-composite-products/wpml-config.xml
+++ b/woocommerce-composite-products/wpml-config.xml
@@ -5,7 +5,6 @@
         <custom-field action="copy">_min_composite_price</custom-field>
         <custom-field action="copy">_max_composite_price</custom-field>
         <custom-field action="copy">_bto_style</custom-field>
-        <custom-field action="copy">_bto_selection_mode</custom-field>
         <custom-field action="copy">_base_regular_price</custom-field>
         <custom-field action="copy">_base_sale_price</custom-field>
         <custom-field action="copy">_base_price</custom-field>


### PR DESCRIPTION
**Summary:** Removes a duplicated custom-field from the WooCommerce Composite Products config.

**Problem:** `_bto_selection_mode` (`action="copy"`) is listed twice in the `<custom-fields>` block (lines 4 and 8).

**Change:** Deletes the redundant second occurrence (line 8), keeping the first (line 4).

**Risk:** None — identical entries.

**Verified:** schema passes · build-index passes · key now appears once · diff is one deletion.