### PR TITLE
WooCommerce Subscriptions - shop_subscription | compsupp-8416

### DIFF
--- a/woocommerce-multilingual/wpml-config.xml
+++ b/woocommerce-multilingual/wpml-config.xml
@@ -73,6 +73,7 @@
 		<custom-type translate="1" automatic="0">product_variation</custom-type>
 		<custom-type translate="0">shop_coupon</custom-type>
 		<custom-type translate="0">shop_order</custom-type>
+		<custom-type translate="0">shop_subscription</custom-type>
 	</custom-types>
 	<taxonomies>
 		<taxonomy translate="1">product_cat</taxonomy>


### PR DESCRIPTION
Set and lock translation preference for `shop_subscription`.

A subscription is a billing record, same nature as shop_order and shouldn't be translated by customers.

Internal ref: [https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8416](https://onthegosystems.myjetbrains.com/youtrack/issue/compsupp-8416)
