### PR TITLE
Timeline widget- Registering Title and Content -  wpmlpb-891

### DIFF
--- a/Divi/wpml-config.xml
+++ b/Divi/wpml-config.xml
@@ -1096,6 +1096,20 @@
                     </key>
                 </key>
             </key>
+            <key name="title">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value" />
+                    </key>
+                </key>
+            </key>
+            <key name="content">
+                <key name="innerContent">
+                    <key name="*">
+                        <key name="value" />
+                    </key>
+                </key>
+            </key>
         </gutenberg-block>
         <gutenberg-block type="divi/team-member" translate="1">
             <key name="name">


### PR DESCRIPTION
The Divi 5 Timeline Title and Content don't show for translation in ATE.

Note: The cause is in wpml-page-builders, not the XML — get_block_config() returns an exact block-level entry without merging the namespace-level keys, so the moment a block registers any field of its own (here date), the divi namespace keys stop applying to it. This will hit any Divi block that gains its own entry.

Ref: https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlpb-891